### PR TITLE
[Feature]: Implementar caché de 5 registros para Juegos con integración de datos remotos

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+ExamAAD1Eval

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,4 +45,5 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    implementation(libs.gson.serializer)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -42,6 +43,12 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+
+    //room
+    implementation(libs.room.runtime)
+    ksp(libs.room.ksp)
+    implementation(libs.room.coroutines)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
@@ -3,9 +3,14 @@ package edu.iesam.examaad1eval
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import androidx.room.Room
+import edu.iesam.examaad1eval.core.data.local.db.Ex2DataBase
 import edu.iesam.examaad1eval.features.ex1.MockEx1RemoteDataSource
 import edu.iesam.examaad1eval.features.ex1.data.Ex1DataRepository
 import edu.iesam.examaad1eval.features.ex1.data.local.xml.Ex1XmlLocalDataSource
+import edu.iesam.examaad1eval.features.ex2.data.Ex2DataRepository
+import edu.iesam.examaad1eval.features.ex2.data.local.db.GameDbLocalDataSource
+import edu.iesam.examaad1eval.features.ex2.data.remote.MockEx2RemoteDataSource
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -34,6 +39,19 @@ class MainActivity : AppCompatActivity() {
         //Ejecutar el ejercicio 2 desde aquí llamando al Ex2DataRepository directamente
         GlobalScope.launch {
             //llamar a Room
+            val db = Room.databaseBuilder(
+                this@MainActivity,
+                Ex2DataBase::class.java,
+                "game-db"
+            ).build()
+
+            val gameDao = db.gameDao()
+
+            val localDataSource = GameDbLocalDataSource(gameDao)
+            val remoteDataSource = MockEx2RemoteDataSource()
+            val ex2DataRepository = Ex2DataRepository(localDataSource, remoteDataSource)
+
+            Log.d("@Ex2", ex2DataRepository.getGames().toString())
         }
     }
 }

--- a/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
@@ -1,7 +1,11 @@
 package edu.iesam.examaad1eval
 
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import edu.iesam.examaad1eval.features.ex1.MockEx1RemoteDataSource
+import edu.iesam.examaad1eval.features.ex1.data.Ex1DataRepository
+import edu.iesam.examaad1eval.features.ex1.data.local.xml.Ex1XmlLocalDataSource
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -14,12 +18,19 @@ class MainActivity : AppCompatActivity() {
         executeExercise2()
     }
 
-    private fun executeExercise1(){
+    private fun executeExercise1() {
         //Ejecutar el ejercicio 1 desde aquí llamando al Ex1DataRepository directamente
+        val localDataSource = Ex1XmlLocalDataSource(this@MainActivity)
+        val remoteDataSource = MockEx1RemoteDataSource()
+        val ex1DataRepository = Ex1DataRepository(localDataSource, remoteDataSource)
+
+        Log.d("@Ex1", ex1DataRepository.getUsers().toString())
+        Log.d("@Ex1", ex1DataRepository.getItems().toString())
+        Log.d("@Ex1", ex1DataRepository.getServices().toString())
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    private fun executeExercise2(){
+    private fun executeExercise2() {
         //Ejecutar el ejercicio 2 desde aquí llamando al Ex2DataRepository directamente
         GlobalScope.launch {
             //llamar a Room

--- a/app/src/main/java/edu/iesam/examaad1eval/core/data/local/db/Ex2DataBase.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/core/data/local/db/Ex2DataBase.kt
@@ -1,0 +1,15 @@
+package edu.iesam.examaad1eval.core.data.local.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import edu.iesam.examaad1eval.features.ex2.data.local.db.GameDao
+import edu.iesam.examaad1eval.features.ex2.data.local.db.GameEntity
+import edu.iesam.examaad1eval.core.data.local.db.converters.PlayerConverter
+
+@Database(entities = [GameEntity::class], version = 1, exportSchema = false)
+@TypeConverters(PlayerConverter::class)
+abstract class Ex2DataBase : RoomDatabase() {
+
+    abstract fun gameDao(): GameDao
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/core/data/local/db/converters/PlayerConverter.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/core/data/local/db/converters/PlayerConverter.kt
@@ -1,0 +1,21 @@
+package edu.iesam.examaad1eval.core.data.local.db.converters
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import edu.iesam.examaad1eval.features.ex2.domain.Player
+
+class PlayerConverter {
+
+    @TypeConverter
+    fun from(player: String): List<Player> {
+        val type = object : TypeToken<List<Player>>() {}.type
+        return Gson().fromJson(player, type)
+    }
+
+    @TypeConverter
+    fun to(player: List<Player>): String {
+        val type = object : TypeToken<List<Player>>() {}.type
+        return Gson().toJson(player, type)
+    }
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/MockEx1RemoteDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/MockEx1RemoteDataSource.kt
@@ -1,5 +1,9 @@
 package edu.iesam.examaad1eval.features.ex1
 
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
+
 class MockEx1RemoteDataSource {
 
     fun getUsers(): List<User> {

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/Ex1DataRepository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/Ex1DataRepository.kt
@@ -1,0 +1,45 @@
+package edu.iesam.examaad1eval.features.ex1.data
+
+import edu.iesam.examaad1eval.features.ex1.MockEx1RemoteDataSource
+import edu.iesam.examaad1eval.features.ex1.data.local.xml.Ex1XmlLocalDataSource
+import edu.iesam.examaad1eval.features.ex1.domain.Ex1Repository
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
+
+class Ex1DataRepository(
+    private val local: Ex1XmlLocalDataSource,
+    private val remote: MockEx1RemoteDataSource
+) : Ex1Repository {
+
+    override fun getUsers(): List<User> {
+        val localUsers = local.getUsers()
+        if (localUsers.isEmpty()) {
+            val remoteUsers = remote.getUsers()
+            local.saveAllUsers(remoteUsers)
+            return remoteUsers
+        }
+        return localUsers
+    }
+
+    override fun getItems(): List<Item> {
+        val localItems = local.getItems()
+        if (localItems.isEmpty()) {
+            val remoteItems = remote.getItems()
+            local.saveAllItems(remoteItems)
+            return remoteItems
+        }
+        return localItems
+    }
+
+    override fun getServices(): List<Services> {
+        val localServices = local.getServices()
+        if (localServices.isEmpty()) {
+            val remoteServices = remote.getServices()
+            local.saveAllServices(remoteServices)
+            return remoteServices
+        }
+        return localServices
+    }
+
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/xml/Ex1XmlLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/xml/Ex1XmlLocalDataSource.kt
@@ -1,0 +1,49 @@
+package edu.iesam.examaad1eval.features.ex1.data.local.xml
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
+
+class Ex1XmlLocalDataSource(private val context: Context) {
+    val fileName = "db-exam"
+
+    val sharedPreferences = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+
+    val gson = Gson()
+
+    fun saveAllUsers(users: List<User>) {
+        val usersJson = gson.toJson(users)
+        sharedPreferences.edit().putString("users", usersJson).apply()
+    }
+
+    fun getUsers(): List<User> {
+        val usersJson = sharedPreferences.getString("users", null) ?: return emptyList()
+        val type = object : TypeToken<List<User>>() {}.type
+        return gson.fromJson(usersJson, type) ?: emptyList()
+    }
+
+    fun saveAllItems(items: List<Item>) {
+        val itemsJson = gson.toJson(items)
+        sharedPreferences.edit().putString("items", itemsJson).apply()
+    }
+
+    fun getItems(): List<Item> {
+        val itemsJson = sharedPreferences.getString("items", null) ?: return emptyList()
+        val type = object : TypeToken<List<Item>>() {}.type
+        return gson.fromJson(itemsJson, type) ?: emptyList()
+    }
+
+    fun saveAllServices(services: List<Services>) {
+        val servicesJson = gson.toJson(services)
+        sharedPreferences.edit().putString("services", servicesJson).apply()
+    }
+
+    fun getServices(): List<Services> {
+        val servicesJson = sharedPreferences.getString("services", null) ?: return emptyList()
+        val type = object : TypeToken<List<Services>>() {}.type
+        return gson.fromJson(servicesJson, type) ?: emptyList()
+    }
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Models.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Models.kt
@@ -1,4 +1,4 @@
-package edu.iesam.examaad1eval.features.ex1
+package edu.iesam.examaad1eval.features.ex1.domain
 
 data class User(val id: String, val name: String, val surname: String)
 data class Item(val id: String, val name: String, val price: Double)

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Repository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Repository.kt
@@ -1,4 +1,4 @@
-package edu.iesam.examaad1eval.features.ex1
+package edu.iesam.examaad1eval.features.ex1.domain
 
 interface Ex1Repository {
     fun getUsers(): List<User>

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/Ex2DataRepository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/Ex2DataRepository.kt
@@ -1,0 +1,16 @@
+package edu.iesam.examaad1eval.features.ex2.data
+
+import edu.iesam.examaad1eval.features.ex2.data.local.db.GameDbLocalDataSource
+import edu.iesam.examaad1eval.features.ex2.domain.Ex2Repository
+import edu.iesam.examaad1eval.features.ex2.domain.Game
+
+class Ex2DataRepository(
+    private val local: GameDbLocalDataSource,
+    private val repository: Ex2DataRepository
+) : Ex2Repository {
+
+    override fun getGames(): List<Game> {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/Ex2DataRepository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/Ex2DataRepository.kt
@@ -1,5 +1,6 @@
 package edu.iesam.examaad1eval.features.ex2.data
 
+import android.util.Log
 import edu.iesam.examaad1eval.features.ex2.data.local.db.GameDbLocalDataSource
 import edu.iesam.examaad1eval.features.ex2.data.remote.MockEx2RemoteDataSource
 import edu.iesam.examaad1eval.features.ex2.domain.Ex2Repository
@@ -10,11 +11,28 @@ class Ex2DataRepository(
     private val remote: MockEx2RemoteDataSource
 ) : Ex2Repository {
 
+    private val localSizeLimit = 5
+
     override suspend fun getGames(): List<Game> {
-        remote.getGames().let { games ->
-            local.saveAll(games)
-            return games
+        val localGames = local.getAll()
+        val remoteGames = remote.getGames()
+
+        if (localGames.isEmpty()) {
+            local.saveAll(remoteGames.take(localSizeLimit))
+            return remoteGames
         }
+
+        val syncedList = mutableListOf<Game>()
+        syncedList.addAll(localGames)
+
+        for (item in remoteGames) {
+            if (!syncedList.any { it.id == item.id }) {
+                syncedList.add(item)
+            }
+        }
+
+        local.saveAll(syncedList.take(localSizeLimit))
+        return syncedList
     }
 
 }

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/Ex2DataRepository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/Ex2DataRepository.kt
@@ -1,16 +1,20 @@
 package edu.iesam.examaad1eval.features.ex2.data
 
 import edu.iesam.examaad1eval.features.ex2.data.local.db.GameDbLocalDataSource
+import edu.iesam.examaad1eval.features.ex2.data.remote.MockEx2RemoteDataSource
 import edu.iesam.examaad1eval.features.ex2.domain.Ex2Repository
 import edu.iesam.examaad1eval.features.ex2.domain.Game
 
 class Ex2DataRepository(
     private val local: GameDbLocalDataSource,
-    private val repository: Ex2DataRepository
+    private val remote: MockEx2RemoteDataSource
 ) : Ex2Repository {
 
-    override fun getGames(): List<Game> {
-        TODO("Not yet implemented")
+    override suspend fun getGames(): List<Game> {
+        remote.getGames().let { games ->
+            local.saveAll(games)
+            return games
+        }
     }
 
 }

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/DbMappers.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/DbMappers.kt
@@ -1,0 +1,5 @@
+package edu.iesam.examaad1eval.features.ex2.data.local.db
+
+import edu.iesam.examaad1eval.features.ex2.domain.Game
+
+fun Game.toEntity(): GameEntity = GameEntity()

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/DbMappers.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/DbMappers.kt
@@ -2,4 +2,6 @@ package edu.iesam.examaad1eval.features.ex2.data.local.db
 
 import edu.iesam.examaad1eval.features.ex2.domain.Game
 
-fun Game.toEntity(): GameEntity = GameEntity()
+fun Game.toEntity(): GameEntity = GameEntity(this.id, this.title, this.player)
+
+fun GameEntity.toDomain(): Game = Game(this.id, this.title, this.players)

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameDao.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameDao.kt
@@ -3,10 +3,14 @@ package edu.iesam.examaad1eval.features.ex2.data.local.db
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
+import androidx.room.Query
 
 @Dao
 interface GameDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveAll(vararg games: GameEntity)
+
+    @Query("SELECT * FROM $GAME_TABLE")
+    fun getAll(): List<GameEntity>
 }

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameDao.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameDao.kt
@@ -1,0 +1,12 @@
+package edu.iesam.examaad1eval.features.ex2.data.local.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+
+@Dao
+interface GameDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun saveAll(vararg games: GameEntity)
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameDbLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameDbLocalDataSource.kt
@@ -1,0 +1,11 @@
+package edu.iesam.examaad1eval.features.ex2.data.local.db
+
+import edu.iesam.examaad1eval.features.ex2.domain.Game
+
+class GameDbLocalDataSource(private val gameDao: GameDao) {
+
+    suspend fun saveAll(games: List<Game>) {
+        val gamesList = games.map { it.toEntity() }
+        gameDao.saveAll(*gamesList.toTypedArray())
+    }
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameDbLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameDbLocalDataSource.kt
@@ -8,4 +8,8 @@ class GameDbLocalDataSource(private val gameDao: GameDao) {
         val gamesList = games.map { it.toEntity() }
         gameDao.saveAll(*gamesList.toTypedArray())
     }
+
+    fun getAll() : List<Game>{
+        return gameDao.getAll().map { it.toDomain() }
+    }
 }

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameEntity.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameEntity.kt
@@ -1,17 +1,15 @@
 package edu.iesam.examaad1eval.features.ex2.data.local.db
 
 import androidx.room.ColumnInfo
-import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import edu.iesam.examaad1eval.features.ex2.domain.Player
 
 const val GAME_TABLE = "game"
-const val GAME_ID = "game_id"
 
 @Entity(tableName = GAME_TABLE)
 data class GameEntity(
-    @PrimaryKey @ColumnInfo(name = GAME_ID) val id: String,
+    @PrimaryKey @ColumnInfo(name = "id") val id: String,
     @ColumnInfo(name = "title") val title: String,
-    @Embedded(prefix = "players") val players: List<Player>
+    @ColumnInfo(name = "players") val players: List<Player>
 )

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameEntity.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/local/db/GameEntity.kt
@@ -1,0 +1,17 @@
+package edu.iesam.examaad1eval.features.ex2.data.local.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import edu.iesam.examaad1eval.features.ex2.domain.Player
+
+const val GAME_TABLE = "game"
+const val GAME_ID = "game_id"
+
+@Entity(tableName = GAME_TABLE)
+data class GameEntity(
+    @PrimaryKey @ColumnInfo(name = GAME_ID) val id: String,
+    @ColumnInfo(name = "title") val title: String,
+    @Embedded(prefix = "players") val players: List<Player>
+)

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/remote/MockEx2RemoteDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/data/remote/MockEx2RemoteDataSource.kt
@@ -1,11 +1,17 @@
-package edu.iesam.examaad1eval.features.ex2
+package edu.iesam.examaad1eval.features.ex2.data.remote
+
+import edu.iesam.examaad1eval.features.ex2.domain.Game
+import edu.iesam.examaad1eval.features.ex2.domain.Player
+import kotlin.collections.first
+import kotlin.collections.last
+import kotlin.collections.shuffled
 
 class MockEx2RemoteDataSource {
 
     fun getGames(): List<Game>{
         return listOf(
             Game("1", "Day of Tentacle", getPlayers()),
-            Game("2", "Monkey Island", listOf( getPlayers().first())),
+            Game("2", "Monkey Island", listOf(getPlayers().first())),
             Game("4", "Comandos 1", listOf(getPlayers().last())),
             Game("5", "Comandos 2", listOf(getPlayers().last())),
             Game("6", "Comandos 3", listOf(getPlayers().last())),

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/domain/Ex2Models.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/domain/Ex2Models.kt
@@ -1,4 +1,4 @@
-package edu.iesam.examaad1eval.features.ex2
+package edu.iesam.examaad1eval.features.ex2.domain
 
 data class Game(val id: String, val title: String, val player: List<Player>)
 data class Player(val id: String, val name: String)

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/domain/Ex2Repository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/domain/Ex2Repository.kt
@@ -1,4 +1,4 @@
-package edu.iesam.examaad1eval.features.ex2
+package edu.iesam.examaad1eval.features.ex2.domain
 
 interface Ex2Repository {
     fun getGames(): List<Game>

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex2/domain/Ex2Repository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex2/domain/Ex2Repository.kt
@@ -1,5 +1,5 @@
 package edu.iesam.examaad1eval.features.ex2.domain
 
 interface Ex2Repository {
-    fun getGames(): List<Game>
+    suspend fun getGames(): List<Game>
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ appcompat = "1.7.0"
 material = "1.12.0"
 activity = "1.9.3"
 constraintlayout = "2.2.0"
+gson = "2.11.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -19,6 +20,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+gson-serializer = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ material = "1.12.0"
 activity = "1.9.3"
 constraintlayout = "2.2.0"
 gson = "2.11.0"
+room-version = "2.6.1"
+kspVersion = "2.0.21-1.0.26"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -21,8 +23,11 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 gson-serializer = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room-version" }
+room-ksp = { group = "androidx.room", name = "room-compiler", version.ref = "room-version" }
+room-coroutines = { group = "androidx.room", name = "room-ktx", version.ref = "room-version" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-
+ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.6.0"
-kotlin = "1.9.0"
+agp = "8.6.1"
+kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -11,7 +11,7 @@ activity = "1.9.3"
 constraintlayout = "2.2.0"
 gson = "2.11.0"
 room-version = "2.6.1"
-kspVersion = "2.0.21-1.0.26"
+kspVersion = "2.0.21-1.0.27"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## 📝 Breve descripción del ticket asociado a esta PR
Implementación de una caché para la base de datos de **Games** utilizando **Room**. La caché permite almacenar únicamente los primeros 5 registros. Si se obtienen más de 5 registros desde remoto, los juegos adicionales se integran con los de la caché, asegurando que no haya duplicados y que todos los registros necesarios sean devueltos al usuario.

## 👩‍💻 Resumen de los cambios introducidos
1. **Restricción de caché a 5 registros en Room**:
   - Lógica para almacenar únicamente 5 registros en la tabla de Juegos (Games).
   - Método en el DAO para devolver games.

2. **Integración de datos remotos con la caché**:
   - Consulta inicial al repositorio:
     - Si no hay datos en local, se obtienen los registros de remoto.
     - Se almacenan los 5 primeros registros en caché, pero se devuelven todos los registros obtenidos de remoto al usuario.
   - Consulta si existen datos en local:
     - Se combinan los registros locales con los datos remotos faltantes hasta completar el listado de 8 juegos, asegurando que no haya duplicados y se almacenan los datos en cache si es que todavía no hay 5 registros almacenados.

## 📸 Screenshots o Video
(No aplica en esta PR)

## ✅ Checklist
- [x] La rama tiene el formato correcto: tipo_de_issue/numero_issue/descripcion.
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [ ] He asignado a dos revisores.
- [x] He relacionado la PR con la Issue.